### PR TITLE
Make Solid 2 admin runtime explicit

### DIFF
--- a/apps/admin/.env.production.example
+++ b/apps/admin/.env.production.example
@@ -4,6 +4,9 @@
 # ============================================
 
 # Deliberately invalid placeholder: startup rejects it until replaced.
+# Solid 2 admin runtime mode
+ADMIN_V2_RUNTIME=production
+
 BETTER_AUTH_SECRET=replace-me
 BETTER_AUTH_URL=https://admin.y4h.org
 PUBLIC_SITE_URL=https://y4h.org

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -99,6 +99,9 @@ services:
     env_file: ../apps/admin/.env.production
     environment:
       PORT: 3002
+      # Keep the runtime mode explicit; the Solid 2 server bundle validates
+      # the complete production contract only in this mode.
+      ADMIN_V2_RUNTIME: production
     expose:
       - "3002"
     depends_on:


### PR DESCRIPTION
The production admin image validates its Solid 2 runtime contract only in production mode. Make that mode explicit in Compose and document it in the production env example.