### PR TITLE
Fix three Listmonk adapter rejections of Go zero values

### DIFF
--- a/apps/admin-v2/src/features/email-settings/contracts.ts
+++ b/apps/admin-v2/src/features/email-settings/contracts.ts
@@ -45,6 +45,22 @@ const duration = v.pipe(
 	),
 	v.check(durationFitsGoRange, 'Duration exceeds Listmonk’s supported range.'),
 );
+// Listmonk leaves these empty while their feature toggle is off. The owning
+// schema requires a real value only when the matching toggle is on.
+const optionalDuration = v.pipe(
+	v.string(),
+	v.trim(),
+	v.maxLength(64, 'Duration is too long.'),
+	v.check(
+		(value) => value === '' || new RegExp(`^${GO_DURATION_HTML_PATTERN}$`, 'u').test(value),
+		'Use a Go duration such as 500ms, 15m, 1h, or 1h30m.',
+	),
+	v.check(
+		(value) => value === '' || durationFitsGoRange(value),
+		'Duration exceeds Listmonk’s supported range.',
+	),
+);
+const optionalCronSchedule = v.pipe(v.string(), v.trim(), v.maxLength(100));
 const port = v.pipe(v.number(), v.safeInteger(), v.minValue(1), v.maxValue(65_535));
 const boundedInteger = v.pipe(v.number(), v.safeInteger(), v.minValue(0), v.maxValue(10_000));
 const fromAddress = v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(255));
@@ -130,17 +146,33 @@ export const SaveEmailGeneralSettingsCommandSchema = v.strictObject({
 	publicArchiveRssContentEnabled: v.boolean(),
 });
 
-export const EmailPerformanceSettingsSchema = v.strictObject({
-	concurrency: performanceInteger(1, 10_000),
-	messageRate: performanceInteger(1, 100_000),
-	batchSize: performanceInteger(1, 100_000),
-	maxSendErrors: performanceInteger(0, 100_000),
-	slidingWindow: v.boolean(),
-	slidingWindowRate: performanceInteger(0, 10_000_000),
-	slidingWindowDuration: duration,
-	cacheSlowQueries: v.boolean(),
-	cacheSlowQueriesInterval: v.pipe(v.string(), v.trim(), v.minLength(1, 'Enter the five-field cron schedule.'), v.maxLength(100)),
-});
+export const EmailPerformanceSettingsSchema = v.pipe(
+	v.strictObject({
+		concurrency: performanceInteger(1, 10_000),
+		messageRate: performanceInteger(1, 100_000),
+		batchSize: performanceInteger(1, 100_000),
+		maxSendErrors: performanceInteger(0, 100_000),
+		slidingWindow: v.boolean(),
+		slidingWindowRate: performanceInteger(0, 10_000_000),
+		slidingWindowDuration: optionalDuration,
+		cacheSlowQueries: v.boolean(),
+		cacheSlowQueriesInterval: optionalCronSchedule,
+	}),
+	v.forward(
+		v.check(
+			(input) => !input.slidingWindow || input.slidingWindowDuration !== '',
+			'Enter a duration.',
+		),
+		['slidingWindowDuration'],
+	),
+	v.forward(
+		v.check(
+			(input) => !input.cacheSlowQueries || input.cacheSlowQueriesInterval !== '',
+			'Enter the five-field cron schedule.',
+		),
+		['cacheSlowQueriesInterval'],
+	),
+);
 
 export const SaveEmailPerformanceSettingsCommandSchema = EmailPerformanceSettingsSchema;
 

--- a/apps/admin-v2/src/integrations/listmonk/campaign-manager.server.test.ts
+++ b/apps/admin-v2/src/integrations/listmonk/campaign-manager.server.test.ts
@@ -74,6 +74,11 @@ describe('Listmonk campaign manager', () => {
 	it('accepts Listmonk v6 empty-catalog metadata omission but rejects incomplete and duplicate catalogs', async () => {
 		await expect(createListmonkCampaignManager(config, vi.fn(async () => json({ data: { results: [] } }))).list()).resolves.toEqual([]);
 		await expect(createListmonkCampaignManager(config, vi.fn(async () => json({ data: { results: [], total: 0, page: 1, per_page: 1000 } }))).list()).resolves.toEqual([]);
+		// The real zero-campaign response. Rejecting these Go zero values
+		// blanked the campaigns page and the analytics page, which loads it.
+		await expect(createListmonkCampaignManager(config, vi.fn(async () => json({
+			data: { results: [], search: '', query: '', total: 0, per_page: 0, page: 0 },
+		}))).list()).resolves.toEqual([]);
 		await expect(createListmonkCampaignManager(config, vi.fn(async () => json({ data: { results: [], total: 1, page: 1, per_page: 1000 } }))).list()).rejects.toThrow('incomplete');
 		await expect(createListmonkCampaignManager(config, vi.fn(async () => json({ data: { results: [providerCampaign()], total: 2, page: 1, per_page: 1000 } }))).list()).rejects.toThrow('incomplete');
 		await expect(createListmonkCampaignManager(config, vi.fn(async () => json({ data: { results: [providerCampaign(), providerCampaign()], total: 2, page: 1, per_page: 1000 } }))).list()).rejects.toThrow('duplicate');

--- a/apps/admin-v2/src/integrations/listmonk/campaign-manager.server.ts
+++ b/apps/admin-v2/src/integrations/listmonk/campaign-manager.server.ts
@@ -60,9 +60,11 @@ const campaignResponseSchema = v.object({ data: campaignSchema });
 const campaignCatalogResponseSchema = v.object({
 	data: v.object({
 		results: v.array(campaignSchema),
+		// Go zero values, not absences: PageResults has no `omitempty`, so an
+		// empty catalog reports 0. The check below owns what that may mean.
 		total: v.optional(nonNegativeInteger),
-		per_page: v.optional(positiveInteger),
-		page: v.optional(positiveInteger),
+		per_page: v.optional(nonNegativeInteger),
+		page: v.optional(nonNegativeInteger),
 	}),
 });
 const deleteResponseSchema = v.object({ data: v.literal(true) });
@@ -158,15 +160,15 @@ export function createListmonkCampaignManager(config: ListmonkConfig, request?: 
 				if (response.results.length > MAX_CAMPAIGNS || (response.total ?? 0) > MAX_CAMPAIGNS) {
 					throw new Error(`Listmonk campaign catalog exceeds the ${MAX_CAMPAIGNS}-campaign safety limit.`);
 				}
-					if (response.results.length === 0) {
-						const metadataIsConsistent =
-							(response.total === undefined || response.total === 0) &&
-							(response.page === undefined || response.page === 1) &&
-							(response.per_page === undefined || response.per_page === MAX_CAMPAIGNS);
-						if (!metadataIsConsistent) throw new Error('Listmonk returned an incomplete campaign catalog.');
-					} else if (response.page !== 1 || response.per_page !== MAX_CAMPAIGNS || response.total !== response.results.length) {
+				if (response.results.length === 0) {
+					// Listmonk returns an empty catalog before setting pagination,
+					// so only total can show the provider withheld rows.
+					if ((response.total ?? 0) !== 0) {
 						throw new Error('Listmonk returned an incomplete campaign catalog.');
 					}
+				} else if (response.page !== 1 || response.per_page !== MAX_CAMPAIGNS || response.total !== response.results.length) {
+					throw new Error('Listmonk returned an incomplete campaign catalog.');
+				}
 				const ids = response.results.map((campaign) => campaign.id);
 				if (new Set(ids).size !== ids.length) throw new Error('Listmonk returned duplicate campaigns.');
 				return response.results.map(normalizeSummary);

--- a/apps/admin-v2/src/integrations/listmonk/email-settings-manager.server.test.ts
+++ b/apps/admin-v2/src/integrations/listmonk/email-settings-manager.server.test.ts
@@ -212,6 +212,36 @@ describe('Listmonk email settings manager', () => {
 		});
 	});
 
+	it('reads the real production document: nil Go slices arrive as null and disabled features leave their duration empty', async () => {
+		const manager = createListmonkEmailSettingsManager(config, vi.fn(async () => json({
+			data: {
+				...createListmonkV62SettingsFixture(),
+				smtp: [{ ...providerServer, email_headers: null, from_addresses: null }],
+				// A nil Go slice marshals to null, never [].
+				'app.notify_emails': null,
+				'privacy.exportable': null,
+				'upload.extensions': null,
+				messengers: null,
+				'bounce.mailboxes': null,
+				// Listmonk stores no duration or cron while the owning toggle is off.
+				'app.message_sliding_window': false,
+				'app.message_sliding_window_duration': '',
+				'app.cache_slow_queries': false,
+				'app.cache_slow_queries_interval': '',
+			},
+		})));
+
+		await expect(manager.readPerformance()).resolves.toMatchObject({
+			slidingWindow: false,
+			slidingWindowDuration: '',
+			cacheSlowQueries: false,
+			cacheSlowQueriesInterval: '',
+		});
+		await expect(manager.readGeneral()).resolves.toMatchObject({ notifyEmails: [] });
+		await expect(manager.readPrivacy()).resolves.toMatchObject({ exportable: [] });
+		await expect(manager.readBounces()).resolves.toMatchObject({ mailboxes: [] });
+	});
+
 	it('serializes concurrent full-document writes and preserves both feature-owned patches', async () => {
 		let current: Record<string, unknown> = {
 			...createListmonkV62SettingsFixture(),

--- a/apps/admin-v2/src/integrations/listmonk/listmonk-settings-document.server.ts
+++ b/apps/admin-v2/src/integrations/listmonk/listmonk-settings-document.server.ts
@@ -267,6 +267,45 @@ async function serializeSettingsWrite<T>(
 }
 
 /**
+ * Listmonk marshals a nil Go slice as JSON `null`, not `[]`. Only these keys
+ * can arrive null; every other slice setting is rebuilt with `make(...)` in
+ * the provider's write path, so `null` there is a real protocol violation and
+ * must still fail loudly. `bounce.actions` is excluded too — it is a map, and
+ * `{}` would fail validation anyway.
+ */
+const NIL_SLICE_SETTING_KEYS = [
+	'app.notify_emails',
+	'privacy.exportable',
+	'upload.extensions',
+	'messengers',
+	'bounce.mailboxes',
+] as const;
+const NIL_SLICE_SMTP_KEYS = ['email_headers', 'from_addresses'] as const;
+
+/**
+ * Mutates the parsed response in place: the caller owns it, and editing it
+ * directly keeps unknown provider keys intact for the GET/merge/PUT cycle.
+ */
+function normalizeListmonkNilSlices(document: ListmonkSettingsDocument): ListmonkSettingsDocument {
+	for (const key of NIL_SLICE_SETTING_KEYS) {
+		if (document[key] === null) document[key] = [];
+	}
+
+	const smtp = document['smtp'];
+	if (Array.isArray(smtp)) {
+		for (const block of smtp) {
+			if (typeof block !== 'object' || block === null) continue;
+			const entry = block as Record<string, unknown>;
+			for (const key of NIL_SLICE_SMTP_KEYS) {
+				if (entry[key] === null) entry[key] = [];
+			}
+		}
+	}
+
+	return document;
+}
+
+/**
  * Owns Listmonk's full settings document lifecycle. Every mutation is one
  * serialized fresh GET, allowlisted in-memory patch, and full PUT.
  */
@@ -275,11 +314,13 @@ export function createListmonkSettingsDocumentCoordinator(
 	transport: ListmonkTransport,
 ) {
 	async function read(): Promise<ListmonkSettingsDocument> {
-		return parseListmonkValue(
-			settingsEnvelopeSchema,
-			await transport.json('/settings'),
-			'settings',
-		).data;
+		return normalizeListmonkNilSlices(
+			parseListmonkValue(
+				settingsEnvelopeSchema,
+				await transport.json('/settings'),
+				'settings',
+			).data,
+		);
 	}
 
 	return {


### PR DESCRIPTION
Four admin-v2 pages failed to load behind an opaque `Reference: <hex>` 500. Three independent bugs, one shared theme: admin-v2 modelled a Go zero value as invalid.

**None of these were caused by the Listmonk v6.2 upgrade.** `git diff v6.0.0 v6.2.0 -- internal/core/settings.go` is empty and no migration writes `null`. They surfaced when admin-v2 replaced the legacy admin, which never validated provider responses.

| symptom | cause |
|---|---|
| bounces + privacy blank, **all 5 settings saves broken** | 4 settings stored as JSON `null` (nil Go slice) |
| performance blank | `duration`/cron required `minLength(1)`; Listmonk stores `""` while the toggle is **off** |
| campaigns + analytics blank | `PageResults` has no `omitempty`, so an empty catalog sends `page: 0, per_page: 0` |

The campaigns bug took analytics down with it — that page loads the same catalog at `analytics/index.tsx:38`.

### Notes

- **Settings normalization is scoped from Listmonk's Go struct, not from our database.** `privacy.domain_allowlist`, `privacy.domain_blocklist`, `security.trusted_urls`, and `smtp` are provably rebuilt with `make(...)` in the provider's write path, so `null` there remains a loud failure. `bounce.actions` is excluded as well: it is a map, and `{}` would fail the contract anyway, turning a clear error into a confusing one.
- **It runs in `read()`, before `validateListmonkV62SettingsDocument`**, which returns its input by identity so unknown provider keys survive the GET/merge/PUT cycle. Normalizing inside the validator would be silently discarded. It is deliberately not in `transport.json()`, which also serves campaigns and subscribers.
- **The campaigns fix is not a widened schema.** The real gate was a completeness check asserting `page === 1 && per_page === MAX_CAMPAIGNS` against a response where Listmonk never sets pagination. Those fields describe nothing when `results` is empty; only `total` can reveal withheld rows. The check got shorter, and a mis-indented block went with it.

### Production data

The four `null` settings were repaired separately via `PUT /api/settings/:key` and are already live, which is why bounces and privacy recovered before this PR. That also unbroke Listmonk's own admin UI, which dereferences `bounce.mailboxes` unguarded in `Settings.vue:133` and `settings/bounces.vue:178`.

### Testing

```
tsc --noEmit   clean
oxlint         clean
vitest         469 passed | 9 skipped
```

Regression tests use the exact production payloads. The existing wrong-type sweep at `listmonk-settings-document.server.test.ts:156` substitutes `{}` for arrays and never `null`, so this class was invisible to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)